### PR TITLE
added HRP address validation to osmosis

### DIFF
--- a/src/hooks/useSendValidate.ts
+++ b/src/hooks/useSendValidate.ts
@@ -106,7 +106,8 @@ const useSendValidate = (): {
     } else if (toBlockChain === BlockChainType.osmo) {
       try {
         Bech32Address.validate(toAddress)
-        validAddress = true;
+        const toAddressHRP = toAddress.slice(0,toAddress.lastIndexOf("1"))
+        validAddress = toAddressHRP === "osmo";
       } catch (error) {
         validAddress = false;
       }


### PR DESCRIPTION
Hello,

This change is an attempt to solve the issue https://github.com/terra-money/bridge-web-app/issues/106. I added an additional validation check for the human readable part of the address when sending to osmosis. Hopefully an additional check to avoid the mistake of people sending to their cosmos address instead of osmosis.

Let know about any feedback.